### PR TITLE
Issue #3264, fix error handling when spider is not matched

### DIFF
--- a/scrapy/commands/parse.py
+++ b/scrapy/commands/parse.py
@@ -146,7 +146,8 @@ class Command(BaseRunSpiderCommand):
 
         def _start_requests(spider):
             yield self.prepare_request(spider, Request(url), opts)
-        self.spidercls.start_requests = _start_requests
+        if self.spidercls:
+            self.spidercls.start_requests = _start_requests
 
     def start_parsing(self, url, opts):
         self.crawler_process.crawl(self.spidercls, **opts.spargs)

--- a/tests/test_command_parse.py
+++ b/tests/test_command_parse.py
@@ -1,6 +1,7 @@
 import os
 import argparse
 from os.path import join, abspath, isfile, exists
+
 from twisted.internet import defer
 from scrapy.commands import parse
 from scrapy.settings import Settings
@@ -221,6 +222,10 @@ ITEM_PIPELINES = {{'{self.project_name}.pipelines.MyPipeline': 1}}
         )
         self.assertRegex(_textmode(out), r"""# Scraped Items  -+\n\[\]""")
         self.assertIn("""Cannot find a rule that matches""", _textmode(stderr))
+
+        status, out, stderr = yield self.execute([self.url('/invalid_url')])
+        self.assertEqual(status, 0)
+        self.assertIn("""""", _textmode(stderr))
 
     @defer.inlineCallbacks
     def test_output_flag(self):

--- a/tests/test_command_parse.py
+++ b/tests/test_command_parse.py
@@ -223,9 +223,10 @@ ITEM_PIPELINES = {{'{self.project_name}.pipelines.MyPipeline': 1}}
         self.assertRegex(_textmode(out), r"""# Scraped Items  -+\n\[\]""")
         self.assertIn("""Cannot find a rule that matches""", _textmode(stderr))
 
+    @defer.inlineCallbacks
+    def test_crawlspider_not_exists_with_not_matched_url(self):
         status, out, stderr = yield self.execute([self.url('/invalid_url')])
         self.assertEqual(status, 0)
-        self.assertIn("""""", _textmode(stderr))
 
     @defer.inlineCallbacks
     def test_output_flag(self):


### PR DESCRIPTION
Fix issue #3264, handle AtrributeError for non-matched Spider

Major Changes

Implementation:
- Check whether Spider exists or is None, and if it's None skip execution of start_requests() with non-existing Spider

Testing:
- Add a test case with invalid URL as parameter inside test_command_parse.py
  Test proves that non-matched Spider does not throw an AttributeError